### PR TITLE
Add edge-case and stress tests with structured JSONL plugin

### DIFF
--- a/src/plugins/jsonl_struct.rs
+++ b/src/plugins/jsonl_struct.rs
@@ -1,0 +1,70 @@
+use crate::plugins::{ChunkScanner, FormatPlugin, ReadSeek, RecordMeta};
+use serde::Deserialize;
+use std::io::{self, BufRead, BufReader, SeekFrom};
+
+#[derive(Default)]
+pub struct JsonlStructPlugin;
+
+impl FormatPlugin for JsonlStructPlugin {
+    fn id(&self) -> &'static str { "jsonl_struct" }
+
+    fn scanner<'a>(&self, file: &'a mut (dyn ReadSeek)) -> io::Result<Box<dyn ChunkScanner + 'a>> {
+        Ok(Box::new(JsonlStructScanner::new(file)))
+    }
+
+    fn encode(&self, ts_ms: i64, value: &serde_json::Value) -> io::Result<Vec<u8>> {
+        // Encode a JSONL line with structured fields alongside the timestamp.
+        let mut obj = value.as_object().cloned().ok_or_else(|| io::Error::new(io::ErrorKind::Other, "expected object"))?;
+        obj.insert("timestamp".to_string(), serde_json::Value::from(ts_ms));
+        let mut line = serde_json::to_vec(&obj).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        line.push(b'\n');
+        Ok(line)
+    }
+}
+
+struct JsonlStructScanner<'a> {
+    reader: BufReader<&'a mut (dyn ReadSeek)>,
+    pos: u64,
+}
+
+impl<'a> JsonlStructScanner<'a> {
+    fn new(file: &'a mut (dyn ReadSeek)) -> Self {
+        let _ = file.seek(SeekFrom::Start(0));
+        Self { reader: BufReader::new(file), pos: 0 }
+    }
+}
+
+impl<'a> ChunkScanner for JsonlStructScanner<'a> {
+    fn next(&mut self) -> io::Result<Option<RecordMeta>> {
+        let buf = self.reader.fill_buf()?;
+        if buf.is_empty() { return Ok(None); }
+        let line_end = match memchr::memchr(b'\n', buf) { Some(i) => i, None => buf.len() };
+        let line = &buf[..line_end];
+        let json = std::str::from_utf8(line).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid utf8 in jsonl"))?;
+        let Rec { timestamp } = serde_json::from_str::<Rec>(json)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "json"))?;
+        let rec_len = line_end as u32 + 1;
+        self.reader.consume(line_end + 1);
+        let meta = RecordMeta { offset: self.pos, len: rec_len, ts_ms: timestamp };
+        self.pos += rec_len as u64;
+        Ok(Some(meta))
+    }
+
+    fn seek_to(&mut self, offset: u64) -> io::Result<()> {
+        use std::io::{Read, Seek, SeekFrom};
+        self.reader.seek(SeekFrom::Start(offset))?;
+        self.pos = offset;
+        if offset == 0 { return Ok(()); }
+        self.reader.seek(SeekFrom::Start(offset - 1))?;
+        let mut b = [0u8;1];
+        let n = self.reader.read(&mut b)?;
+        let prev_is_nl = n == 1 && b[0] == b'\n';
+        if !prev_is_nl {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "seek_to offset not at line boundary"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+struct Rec { timestamp: i64 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -26,6 +26,7 @@ pub trait FormatPlugin: Send + Sync + 'static {
 }
 
 pub mod jsonl;
+pub mod jsonl_struct;
 
 use std::sync::Arc;
 use crate::errors::Result;
@@ -33,6 +34,7 @@ use crate::errors::Result;
 pub fn resolve_plugin(name: &str) -> Result<Arc<dyn FormatPlugin>> {
     match name {
         "jsonl" | "json" => Ok(Arc::new(jsonl::JsonlPlugin::default())),
+        "jsonl_struct" => Ok(Arc::new(jsonl_struct::JsonlStructPlugin::default())),
         other => Err(crate::errors::TvError::Io(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!("unknown plugin: {}", other),

--- a/tests/stress_parallel_tests.rs
+++ b/tests/stress_parallel_tests.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use timevault::config::{StoreConfig, PartitionConfig};
+use timevault::store::Store;
+use timevault::partition::PartitionHandle;
+use timevault::plugins::FormatPlugin;
+
+#[test]
+fn stress_parallel_append_and_read() {
+    const PARTS: usize = 4;
+    const RECORDS_PER_PART: usize = 250_000; // 4 * 250k = 1M records
+
+    let td = TempDir::new().unwrap();
+    let root = td.path().to_path_buf();
+    let store = Store::open(&root, StoreConfig::default()).unwrap();
+
+    let mut handles = Vec::new();
+    for _ in 0..PARTS {
+        let id = Uuid::now_v7();
+        let mut cfg = PartitionConfig::default();
+        cfg.format_plugin = "jsonl_struct".to_string();
+        PartitionHandle::create(root.clone(), id, cfg).unwrap();
+        let h = store.open_partition(id).unwrap();
+        handles.push(h);
+    }
+    let handles: Vec<_> = handles.into_iter().map(|h| Arc::new(h)).collect();
+
+    std::thread::scope(|s| {
+        // Append threads
+        for (idx, h) in handles.iter().cloned().enumerate() {
+            s.spawn(move || {
+                let plugin = timevault::plugins::jsonl_struct::JsonlStructPlugin::default();
+                for i in 0..RECORDS_PER_PART {
+                    let ts = (idx as i64) * 1_000_000 + i as i64;
+                    let payload = serde_json::json!({"a": i, "b": idx});
+                    let line = plugin.encode(ts, &payload).unwrap();
+                    h.append(ts, &line).unwrap();
+                }
+            });
+        }
+        // Read threads
+        for h in handles.iter().cloned() {
+            s.spawn(move || {
+                for i in 0..100 {
+                    let start = (i * 10_000) as i64;
+                    let end = start + 5_000;
+                    let _ = h.read_range(start, end);
+                }
+            });
+        }
+    });
+
+    for h in handles {
+        assert_eq!(h.stats().appends, RECORDS_PER_PART as u64);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `jsonl_struct` plugin for structured test data and register it
- cover append and read_range edge cases
- add 1M-record multi-partition stress test with concurrent appends and reads

## Testing
- `cargo test --tests -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_b_68c2939d9fd4832c815073640bd679a5