### PR TITLE
Hold store write lock for lifetime of Store

### DIFF
--- a/src/store/locks.rs
+++ b/src/store/locks.rs
@@ -1,15 +1,15 @@
-use crate::errors::{TvError, Result};
+use crate::errors::{Result, TvError};
 use fs2::FileExt;
 use std::fs::{File, OpenOptions};
 use std::path::Path;
 
-pub fn acquire_store_lock(root: &Path) -> Result<()> {
+pub fn acquire_store_lock(root: &Path) -> Result<File> {
     let path = root.join(".timevault.write.lock");
     let f = OpenOptions::new().create(true).read(true).write(true).open(&path)?;
     if let Err(_) = f.try_lock_exclusive() { return Err(TvError::AlreadyOpen); }
     write_identity(&f)?;
     f.sync_all()?;
-    Ok(())
+    Ok(f)
 }
 
 fn write_identity(f: &File) -> std::io::Result<()> {


### PR DESCRIPTION
## Summary
- keep the write lock file handle alive by returning it from `acquire_store_lock`
- retain the lock handle inside `Store` when opened for writes
- add a test ensuring a second writer cannot open the store while the first is alive

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68cb93f4b6c4832cad79f82746f2f5ee