### PR TITLE
Make raft integration generic

### DIFF
--- a/src/raft/log.rs
+++ b/src/raft/log.rs
@@ -1,21 +1,19 @@
 use std::io::Cursor;
+use std::marker::PhantomData;
 use std::sync::mpsc::{Receiver, Sender, SyncSender, channel, sync_channel};
 use std::thread;
 
-use openraft::storage::{LogFlushed, RaftLogStorage};
-use openraft::{
-    Entry, EntryPayload, ErrorSubject, ErrorVerb, LogId, LogState,
-    RaftLogReader, StorageError, Vote,
-};
-use serde::{Deserialize, Serialize};
-use tracing::trace;
-use crate::disk::atomic::atomic_write_json;
 use crate::PartitionHandle;
+use crate::disk::atomic::atomic_write_json;
 use crate::errors::TvError;
 use crate::partition::read::read_range_blocks;
-use crate::raft::{TvrRequest, TvrConfig, TvrNodeId};
-use crate::raft::paths;
 use crate::raft::errors::{map_send_err, recv_map, recv_unit};
+use crate::raft::paths;
+use crate::raft::{TvrConfig, TvrNodeId};
+use openraft::storage::{LogFlushed, RaftLogStorage};
+use openraft::{Entry, EntryPayload, ErrorSubject, ErrorVerb, LogId, LogState, RaftLogReader, StorageError, Vote};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tracing::trace;
 
 #[derive(Serialize, Deserialize, Clone)]
 struct JsonlRecord {
@@ -25,34 +23,45 @@ struct JsonlRecord {
     payload: serde_json::Value,
 }
 
-
-enum Op {
+enum Op<D, R>
+where
+    D: serde::Serialize + DeserializeOwned + openraft::AppData,
+    R: openraft::AppDataResponse,
+{
     // list of (order_key=index, encoded)
-    Append(Vec<(u64, Vec<u8>)>, LogFlushed<TvrConfig>),
+    Append(Vec<(u64, Vec<u8>)>, LogFlushed<TvrConfig<D, R>>),
     Read(u64, u64, Sender<Result<Vec<u8>, TvError>>),
     Truncate(u64, Sender<Result<(), TvError>>),
     Purge(LogId<TvrNodeId>, Sender<Result<(), TvError>>),
-    GetState(Sender<Result<LogState<TvrConfig>, TvError>>),
+    GetState(Sender<Result<LogState<TvrConfig<D, R>>, TvError>>),
     SaveVote(Vote<TvrNodeId>, Sender<Result<(), TvError>>),
     ReadVote(Sender<Result<Option<Vote<TvrNodeId>>, TvError>>),
     Shutdown,
 }
 
-pub struct TvrLogAdapter {
+pub struct TvrLogAdapter<D, R>
+where
+    D: serde::Serialize + DeserializeOwned + openraft::AppData,
+    R: openraft::AppDataResponse,
+{
     part: PartitionHandle,
     node_id: TvrNodeId,
-    tx: SyncSender<Op>,
+    tx: SyncSender<Op<D, R>>,
     thread_handle: Option<thread::JoinHandle<()>>,
+    _marker: PhantomData<(D, R)>,
 }
 
-impl TvrLogAdapter {
-
+impl<D, R> TvrLogAdapter<D, R>
+where
+    D: serde::Serialize + DeserializeOwned + openraft::AppData,
+    R: openraft::AppDataResponse,
+{
     pub fn new(part: PartitionHandle, node_id: TvrNodeId) -> Self {
         let cfg = part.cfg();
         if cfg.format_plugin != "jsonl" {
             panic!("Only jsonl format is supported for now.");
         }
-        let (tx, rx) = sync_channel::<Op>(1024);
+        let (tx, rx) = sync_channel::<Op<D, R>>(1024);
         let hpart = part.clone();
         let handle = thread::spawn(move || Self::bg_loop(hpart, rx));
         Self {
@@ -60,10 +69,11 @@ impl TvrLogAdapter {
             node_id,
             tx,
             thread_handle: Some(handle),
+            _marker: PhantomData,
         }
     }
 
-    fn bg_loop(part: PartitionHandle, rx: Receiver<Op>) {
+    fn bg_loop(part: PartitionHandle, rx: Receiver<Op<D, R>>) {
         while let Ok(op) = rx.recv() {
             match op {
                 Op::Append(list, cb) => {
@@ -76,10 +86,7 @@ impl TvrLogAdapter {
                         }
                     }
                     if let Some(e) = first_err {
-                        let _ = cb.log_io_completed(Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            e.to_string(),
-                        )));
+                        let _ = cb.log_io_completed(Err(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())));
                     } else {
                         let _ = cb.log_io_completed(Ok(()));
                     }
@@ -101,7 +108,7 @@ impl TvrLogAdapter {
                 }
                 Op::GetState(tx) => {
                     trace!("bg_loop {}: get state", part.short_id());
-                    let r = get_state(&part);
+                    let r = get_state::<D, R>(&part);
                     tx.send(r).expect("bg_loop: failed to send GetState response");
                 }
                 Op::SaveVote(v, tx) => {
@@ -116,14 +123,18 @@ impl TvrLogAdapter {
                 }
                 Op::Shutdown => {
                     trace!("bg_loop {}: shutdown", part.short_id());
-                    break
-                },
+                    break;
+                }
             }
         }
     }
 }
 
-impl Drop for TvrLogAdapter {
+impl<D, R> Drop for TvrLogAdapter<D, R>
+where
+    D: serde::Serialize + DeserializeOwned + openraft::AppData,
+    R: openraft::AppDataResponse,
+{
     fn drop(&mut self) {
         let _ = self.tx.send(Op::Shutdown);
         if let Some(h) = self.thread_handle.take() {
@@ -132,25 +143,31 @@ impl Drop for TvrLogAdapter {
     }
 }
 
-impl Clone for TvrLogAdapter {
+impl<D, R> Clone for TvrLogAdapter<D, R>
+where
+    D: serde::Serialize + DeserializeOwned + openraft::AppData,
+    R: openraft::AppDataResponse,
+{
     fn clone(&self) -> Self {
         Self {
             part: self.part.clone(),
             node_id: self.node_id.clone(),
             tx: self.tx.clone(),
             thread_handle: None,
+            _marker: PhantomData,
         }
     }
 }
 
-pub(crate) fn encode_entry(e: &Entry<TvrConfig>) -> Vec<u8> {
+pub(crate) fn encode_entry<D, R>(e: &Entry<TvrConfig<D, R>>) -> Vec<u8>
+where
+    D: serde::Serialize + DeserializeOwned + openraft::AppData,
+    R: openraft::AppDataResponse,
+{
     let (kind, val) = match &e.payload {
         EntryPayload::Blank => ("Blank".to_string(), serde_json::Value::Null),
-        EntryPayload::Normal(r) => ("Normal".to_string(), r.0.clone()),
-        EntryPayload::Membership(m) => (
-            "Membership".to_string(),
-            serde_json::to_value(m).unwrap_or(serde_json::Value::Null),
-        ),
+        EntryPayload::Normal(r) => ("Normal".to_string(), serde_json::to_value(r).unwrap_or(serde_json::Value::Null)),
+        EntryPayload::Membership(m) => ("Membership".to_string(), serde_json::to_value(m).unwrap_or(serde_json::Value::Null)),
     };
     let rec = JsonlRecord {
         timestamp: e.log_id.index as i64,
@@ -163,7 +180,11 @@ pub(crate) fn encode_entry(e: &Entry<TvrConfig>) -> Vec<u8> {
     out
 }
 
-pub(crate) fn decode_entries(part : &PartitionHandle, buf: &[u8], range: std::ops::RangeInclusive<u64>) -> Vec<Entry<TvrConfig>> {
+pub(crate) fn decode_entries<D, R>(part: &PartitionHandle, buf: &[u8], range: std::ops::RangeInclusive<u64>) -> Vec<Entry<TvrConfig<D, R>>>
+where
+    D: serde::Serialize + DeserializeOwned + openraft::AppData,
+    R: openraft::AppDataResponse,
+{
     let plugin = match crate::plugins::resolve_plugin("jsonl") {
         Ok(p) => p,
         Err(_) => return Vec::new(),
@@ -179,28 +200,37 @@ pub(crate) fn decode_entries(part : &PartitionHandle, buf: &[u8], range: std::op
         // Safety: meta.len includes the trailing newline, which serde_json tolerates.
         let start = meta.offset as usize;
         let end = start + meta.len as usize;
-        if end > buf.len() { break; }
+        if end > buf.len() {
+            break;
+        }
         let line = &buf[start..end];
         if let Ok(rec) = serde_json::from_slice::<JsonlRecord>(line) {
-            if !range.contains(&rec.log_id.index) { continue; }
+            if !range.contains(&rec.log_id.index) {
+                continue;
+            }
             let payload = match rec.kind.as_str() {
                 "Blank" => EntryPayload::Blank,
-                "Membership" => {
-                    match serde_json::from_value(rec.payload) {
-                        Ok(m) => EntryPayload::Membership(m),
-                        Err(_) => EntryPayload::Blank,
-                    }
-                }
-                _ => EntryPayload::Normal(TvrRequest(rec.payload)),
+                "Membership" => match serde_json::from_value(rec.payload) {
+                    Ok(m) => EntryPayload::Membership(m),
+                    Err(_) => EntryPayload::Blank,
+                },
+                _ => match serde_json::from_value(rec.payload) {
+                    Ok(v) => EntryPayload::Normal(v),
+                    Err(_) => EntryPayload::Blank,
+                },
             };
-            trace!("decode_entries {}: {} {:?}", part.short_id(), rec.log_id, payload.clone());
+            trace!("decode_entries {}: {} {:?}", part.short_id(), rec.log_id, &payload);
             out.push(Entry { log_id: rec.log_id, payload });
         }
     }
     out
 }
 
-pub(crate) fn get_state(part: &PartitionHandle) -> Result<LogState<TvrConfig>, TvError> {
+pub(crate) fn get_state<D, R>(part: &PartitionHandle) -> Result<LogState<TvrConfig<D, R>>, TvError>
+where
+    D: serde::Serialize + DeserializeOwned + openraft::AppData,
+    R: openraft::AppDataResponse,
+{
     let purge = read_purge_file(part).ok().flatten();
 
     let last = part.last_record();
@@ -215,10 +245,7 @@ pub(crate) fn get_state(part: &PartitionHandle) -> Result<LogState<TvrConfig>, T
 
     trace!("get_state: last_log_id={:?}, purge={:?}", last_log_id, purge);
 
-    Ok(LogState {
-        last_purged_log_id: purge,
-        last_log_id,
-    })
+    Ok(LogState { last_purged_log_id: purge, last_log_id })
 }
 
 pub(crate) fn purge_with_persist(part: &PartitionHandle, id: &LogId<TvrNodeId>) -> Result<(), TvError> {
@@ -245,12 +272,7 @@ struct PurgeFile {
 }
 
 pub(crate) fn save_purge_file(part: &PartitionHandle, id: &LogId<TvrNodeId>) -> Result<(), TvError> {
-    atomic_write_json(
-        paths::purge_file(&part),
-        &PurgeFile {
-            last_deleted: id.clone(),
-        },
-    )
+    atomic_write_json(paths::purge_file(&part), &PurgeFile { last_deleted: id.clone() })
 }
 
 pub(crate) fn read_purge_file(part: &PartitionHandle) -> Result<Option<LogId<TvrNodeId>>, TvError> {
@@ -263,11 +285,12 @@ pub(crate) fn read_purge_file(part: &PartitionHandle) -> Result<Option<LogId<Tvr
     Ok(Some(v.last_deleted))
 }
 
-impl RaftLogReader<TvrConfig> for TvrLogAdapter {
-    async fn try_get_log_entries<RB: std::ops::RangeBounds<u64> + Send>(
-        &mut self,
-        range: RB,
-    ) -> Result<Vec<Entry<TvrConfig>>, StorageError<TvrNodeId>> {
+impl<D, R> RaftLogReader<TvrConfig<D, R>> for TvrLogAdapter<D, R>
+where
+    D: serde::Serialize + DeserializeOwned + openraft::AppData,
+    R: openraft::AppDataResponse,
+{
+    async fn try_get_log_entries<RB: std::ops::RangeBounds<u64> + Send>(&mut self, range: RB) -> Result<Vec<Entry<TvrConfig<D, R>>>, StorageError<TvrNodeId>> {
         use std::ops::Bound::*;
         let start = match range.start_bound() {
             Included(a) => *a,
@@ -288,22 +311,22 @@ impl RaftLogReader<TvrConfig> for TvrLogAdapter {
         }
 
         let (rtx, rrx) = channel();
-        self.tx
-            .send(Op::Read(start, end, rtx))
-            .map_err(|e| map_send_err(ErrorSubject::Logs, ErrorVerb::Read, e))?;
+        self.tx.send(Op::Read(start, end, rtx)).map_err(|e| map_send_err(ErrorSubject::Logs, ErrorVerb::Read, e))?;
         let buf = recv_map(rrx, ErrorSubject::Logs, ErrorVerb::Read)?;
         Ok(decode_entries(&self.part, &buf, start..=end))
     }
 }
 
-impl RaftLogStorage<TvrConfig> for TvrLogAdapter {
+impl<D, R> RaftLogStorage<TvrConfig<D, R>> for TvrLogAdapter<D, R>
+where
+    D: serde::Serialize + DeserializeOwned + openraft::AppData,
+    R: openraft::AppDataResponse,
+{
     type LogReader = Self;
 
-    async fn get_log_state(&mut self) -> Result<LogState<TvrConfig>, StorageError<TvrNodeId>> {
+    async fn get_log_state(&mut self) -> Result<LogState<TvrConfig<D, R>>, StorageError<TvrNodeId>> {
         let (rtx, rrx) = channel();
-        self.tx
-            .send(Op::GetState(rtx))
-            .map_err(|e| map_send_err(ErrorSubject::Logs, ErrorVerb::Read, e))?;
+        self.tx.send(Op::GetState(rtx)).map_err(|e| map_send_err(ErrorSubject::Logs, ErrorVerb::Read, e))?;
         recv_map(rrx, ErrorSubject::Logs, ErrorVerb::Read)
     }
 
@@ -313,27 +336,19 @@ impl RaftLogStorage<TvrConfig> for TvrLogAdapter {
 
     async fn save_vote(&mut self, vote: &Vote<TvrNodeId>) -> Result<(), StorageError<TvrNodeId>> {
         let (rtx, rrx) = channel();
-        self.tx
-            .send(Op::SaveVote(vote.clone(), rtx))
-            .map_err(|e| map_send_err(ErrorSubject::Vote, ErrorVerb::Write, e))?;
+        self.tx.send(Op::SaveVote(vote.clone(), rtx)).map_err(|e| map_send_err(ErrorSubject::Vote, ErrorVerb::Write, e))?;
         recv_unit(rrx, ErrorSubject::Vote, ErrorVerb::Write)
     }
 
     async fn read_vote(&mut self) -> Result<Option<Vote<TvrNodeId>>, StorageError<TvrNodeId>> {
         let (rtx, rrx) = channel();
-        self.tx
-            .send(Op::ReadVote(rtx))
-            .map_err(|e| map_send_err(ErrorSubject::Vote, ErrorVerb::Read, e))?;
+        self.tx.send(Op::ReadVote(rtx)).map_err(|e| map_send_err(ErrorSubject::Vote, ErrorVerb::Read, e))?;
         recv_map(rrx, ErrorSubject::Vote, ErrorVerb::Read)
     }
 
-    async fn append<I>(
-        &mut self,
-        entries: I,
-        callback: LogFlushed<TvrConfig>,
-    ) -> Result<(), StorageError<TvrNodeId>>
+    async fn append<I>(&mut self, entries: I, callback: LogFlushed<TvrConfig<D, R>>) -> Result<(), StorageError<TvrNodeId>>
     where
-        I: IntoIterator<Item = Entry<TvrConfig>> + openraft::OptionalSend,
+        I: IntoIterator<Item = Entry<TvrConfig<D, R>>> + openraft::OptionalSend,
         I::IntoIter: openraft::OptionalSend,
     {
         let mut list: Vec<(u64, Vec<u8>)> = Vec::new();
@@ -343,25 +358,19 @@ impl RaftLogStorage<TvrConfig> for TvrLogAdapter {
             let buf = encode_entry(&e);
             list.push((idx, buf));
         }
-        self.tx
-            .send(Op::Append(list, callback))
-            .map_err(|e| map_send_err(ErrorSubject::Logs, ErrorVerb::Write, e))?;
+        self.tx.send(Op::Append(list, callback)).map_err(|e| map_send_err(ErrorSubject::Logs, ErrorVerb::Write, e))?;
         Ok(())
     }
 
     async fn truncate(&mut self, log_id: LogId<TvrNodeId>) -> Result<(), StorageError<TvrNodeId>> {
         let (rtx, rrx) = channel();
-        self.tx
-            .send(Op::Truncate(log_id.index, rtx))
-            .map_err(|e| map_send_err(ErrorSubject::Logs, ErrorVerb::Write, e))?;
+        self.tx.send(Op::Truncate(log_id.index, rtx)).map_err(|e| map_send_err(ErrorSubject::Logs, ErrorVerb::Write, e))?;
         recv_unit(rrx, ErrorSubject::Logs, ErrorVerb::Write)
     }
 
     async fn purge(&mut self, log_id: LogId<TvrNodeId>) -> Result<(), StorageError<TvrNodeId>> {
         let (rtx, rrx) = channel();
-        self.tx
-            .send(Op::Purge(log_id, rtx))
-            .map_err(|e| map_send_err(ErrorSubject::Store, ErrorVerb::Write, e))?;
+        self.tx.send(Op::Purge(log_id, rtx)).map_err(|e| map_send_err(ErrorSubject::Store, ErrorVerb::Write, e))?;
         recv_unit(rrx, ErrorSubject::Store, ErrorVerb::Write)
     }
 }

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -1,36 +1,96 @@
+use std::cmp::Ordering;
 use std::io::Cursor;
-use openraft::{BasicNode, Entry, StorageError, TokioRuntime};
+use std::marker::PhantomData;
+
+use openraft::{AppData, AppDataResponse, BasicNode, Entry, RaftTypeConfig, StorageError, TokioRuntime};
 use serde::{Deserialize, Serialize};
 
-pub mod log;
-pub mod state;
-mod paths;
 mod errors;
+pub mod log;
+mod paths;
+pub mod state;
 
 #[cfg(test)]
 mod tests;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TvrRequest(pub serde_json::Value);
+pub struct TvrConfig<D, R> {
+    _marker: PhantomData<(D, R)>,
+}
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TvrResponse(pub Result<serde_json::Value, serde_json::Value>);
+impl<D, R> Copy for TvrConfig<D, R> {}
 
-openraft::declare_raft_types!(pub TvrConfig:
-    D            = TvrRequest,
-    R            = TvrResponse,
-    NodeId       = TvrNodeId,
-    Node         = BasicNode,
-    Entry        = Entry<TvrConfig>,
-    SnapshotData = Cursor<Vec<u8>>,
-    AsyncRuntime = TokioRuntime,
-);
+impl<D, R> Clone for TvrConfig<D, R> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
-pub type TvRaft = openraft::Raft<TvrConfig>;
-pub type TvrEntry = Entry<TvrConfig>;
+impl<D, R> Default for TvrConfig<D, R> {
+    fn default() -> Self {
+        Self { _marker: PhantomData }
+    }
+}
+
+impl<D, R> std::fmt::Debug for TvrConfig<D, R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TvrConfig<_, _>")
+    }
+}
+
+impl<D, R> PartialEq for TvrConfig<D, R> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<D, R> Eq for TvrConfig<D, R> {}
+
+impl<D, R> PartialOrd for TvrConfig<D, R> {
+    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+        Some(Ordering::Equal)
+    }
+}
+
+impl<D, R> Ord for TvrConfig<D, R> {
+    fn cmp(&self, _other: &Self) -> Ordering {
+        Ordering::Equal
+    }
+}
+
+impl<D, R> RaftTypeConfig for TvrConfig<D, R>
+where
+    D: AppData,
+    R: AppDataResponse,
+{
+    type D = D;
+    type R = R;
+    type NodeId = TvrNodeId;
+    type Node = BasicNode;
+    type Entry = Entry<Self>;
+    type SnapshotData = Cursor<Vec<u8>>;
+    type Responder = openraft::impls::OneshotResponder<Self>;
+    type AsyncRuntime = TokioRuntime;
+}
+
+pub type TvRaft<C> = openraft::Raft<C>;
+pub type TvrEntry<C> = Entry<C>;
 
 pub type TvrNodeId = u64;
 
 pub type TvrNode = BasicNode;
 
 type StorageResult<T> = Result<T, StorageError<TvrNodeId>>;
+
+pub type ValueRequest = serde_json::Value;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValueResponse(pub Result<serde_json::Value, serde_json::Value>);
+
+impl Default for ValueResponse {
+    fn default() -> Self {
+        Self(Ok(serde_json::Value::Null))
+    }
+}
+pub type ValueConfig = TvrConfig<ValueRequest, ValueResponse>;
+pub type ValueLogAdapter = log::TvrLogAdapter<ValueRequest, ValueResponse>;
+pub type ValueStateMachine = state::TvrPartitionStateMachine<ValueRequest, ValueResponse>;


### PR DESCRIPTION
## Summary
- replace the fixed JSON request/response configuration with a generic `TvrConfig<D, R>` and keep JSON-only aliases for tests
- generalize the log adapter and helper functions so they work with any serde-compatible request type
- make the partition state machine generic and update the raft tests to use the new value-based aliases

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68d0fcf96af0832cb66e1d9befa34ac1