### PR TITLE
Remove TvrLogAdapter RaftLogReader impl

### DIFF
--- a/doc/openraft_log_storage.md
+++ b/doc/openraft_log_storage.md
@@ -6,7 +6,8 @@ the necessary mapping.
 - targeted minimum OpenRaft version is: 0.9.21
 - one OpenRaft node per timevault partition
 
-- The adapter should implement `RaftLogStorage` and `RaftLogReader` with the following details.
+- The adapter should implement `RaftLogStorage` and expose a dedicated type that implements
+  `RaftLogReader` with the following details.
 - The adapter should not implement `RaftStateStorage`.
 
 ## Mapping
@@ -32,7 +33,8 @@ a format plugin is required.
 - Module name: `raft`
 - Required feature: none, the module is included by default
 - Adapter struct name: `TvrLogAdapter`
-  - implements both `RaftLogStorage` and `RaftLogReader`
+  - implements `RaftLogStorage`
+  - provides a `TvrLogReader` that implements `RaftLogReader`
   - contains all necessary data for the adapter to operate
 - Define `RaftTypeConfig` with these types:
   - `D`: `Request(serde_json::Value)` (define the struct Request)


### PR DESCRIPTION
## Summary
- keep the `RaftLogReader` implementation solely on `TvrLogReader` instead of also implementing it on `TvrLogAdapter`
- update the OpenRaft storage integration notes to describe the dedicated reader type

## Testing
- `cargo test --package timevault --lib` *(fails: unable to download `actix-web` due to CONNECT tunnel 403 while updating crates.io index)*

------
https://chatgpt.com/codex/tasks/task_b_68d38832edfc832c9d1b392f43aebb68