### PR TITLE
Add event state handling and transfer endpoints to OpenRaft example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,6 +1518,7 @@ dependencies = [
  "maplit",
  "openraft",
  "openraft-macros",
+ "parking_lot",
  "reqwest",
  "serde",
  "serde_json",

--- a/examples/openraft-example/Cargo.toml
+++ b/examples/openraft-example/Cargo.toml
@@ -18,3 +18,4 @@ openraft-macros = "0.9.21"
 reqwest = { version = "0.12.23", features = ["json"] }
 anyhow = "1.0.63"
 maplit = "1.0.2"
+parking_lot = "0.12"

--- a/examples/openraft-example/src/app.rs
+++ b/examples/openraft-example/src/app.rs
@@ -1,10 +1,110 @@
-use crate::TvrNodeId;
+use crate::PartitionHandle;
 use crate::Raft;
+use crate::TvrNodeId;
+use crate::state::{DeviceStatus, SharedDeviceState};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use timevault::errors::{Result as TvResult, TvError};
+use timevault::store::paths;
+use timevault::store::transfer::{DataTransfer, FileDownload, ManifestDownload, TransferRange};
+use uuid::Uuid;
 
 // Representation of an application state. This struct can be shared around to share
 // instances of raft, store and more.
 pub struct App {
     pub id: TvrNodeId,
     pub addr: String,
-    pub raft: Raft
+    pub raft: Raft,
+    pub devices: SharedDeviceState,
+    pub event_partition: PartitionHandle,
+}
+
+impl App {
+    pub fn snapshot_devices(&self) -> Vec<DeviceStatus> {
+        self.devices.read().values().cloned().collect()
+    }
+
+    fn ensure_partition(&self, partition: Uuid) -> TvResult<()> {
+        if partition == self.event_partition.id() {
+            Ok(())
+        } else {
+            Err(TvError::PartitionNotFound(partition))
+        }
+    }
+
+    fn manifest_path(&self) -> std::path::PathBuf {
+        let part_dir = paths::partition_dir(self.event_partition.root(), self.event_partition.id());
+        paths::partition_manifest(&part_dir)
+    }
+
+    fn chunk_path(&self, chunk_id: u64) -> std::path::PathBuf {
+        let part_dir = paths::partition_dir(self.event_partition.root(), self.event_partition.id());
+        let chunks_dir = paths::chunks_dir(&part_dir);
+        paths::chunk_file(&chunks_dir, chunk_id)
+    }
+
+    fn index_path(&self, chunk_id: u64) -> std::path::PathBuf {
+        let part_dir = paths::partition_dir(self.event_partition.root(), self.event_partition.id());
+        let chunks_dir = paths::chunks_dir(&part_dir);
+        paths::index_file(&chunks_dir, chunk_id)
+    }
+
+    fn read_range(path: &std::path::Path, range: TransferRange) -> TvResult<(Vec<u8>, u64)> {
+        let mut file = File::open(path)?;
+        let metadata = file.metadata()?;
+        let len = metadata.len();
+        if range.start > len {
+            return Err(TvError::InvalidRange { from: range.start as i64, to: len as i64 });
+        }
+        file.seek(SeekFrom::Start(range.start))?;
+        let end = range.end.unwrap_or(len);
+        let end = end.min(len);
+        if end < range.start {
+            return Err(TvError::InvalidRange { from: range.start as i64, to: end as i64 });
+        }
+        let mut buf = vec![0u8; (end - range.start) as usize];
+        file.read_exact(&mut buf)?;
+        Ok((buf, len))
+    }
+}
+
+impl DataTransfer for App {
+    fn download_manifest(&self, partition: Uuid) -> TvResult<ManifestDownload> {
+        self.ensure_partition(partition)?;
+        let manifest_path = self.manifest_path();
+        let lines = timevault::store::disk::manifest::load_manifest(&manifest_path)?;
+        Ok(ManifestDownload {
+            partition_id: partition,
+            lines,
+            version: None,
+        })
+    }
+
+    fn download_chunk(&self, partition: Uuid, chunk_id: u64, range: TransferRange) -> TvResult<FileDownload> {
+        self.ensure_partition(partition)?;
+        let path = self.chunk_path(chunk_id);
+        let (bytes, remote_len) = Self::read_range(&path, range)?;
+        Ok(FileDownload {
+            partition_id: partition,
+            chunk_id,
+            requested_range: range,
+            bytes,
+            remote_len,
+            version: None,
+        })
+    }
+
+    fn download_index(&self, partition: Uuid, chunk_id: u64, range: TransferRange) -> TvResult<FileDownload> {
+        self.ensure_partition(partition)?;
+        let path = self.index_path(chunk_id);
+        let (bytes, remote_len) = Self::read_range(&path, range)?;
+        Ok(FileDownload {
+            partition_id: partition,
+            chunk_id,
+            requested_range: range,
+            bytes,
+            remote_len,
+            version: None,
+        })
+    }
 }

--- a/examples/openraft-example/src/bin/main.rs
+++ b/examples/openraft-example/src/bin/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use tracing_subscriber::EnvFilter;
 use openraft_example::start_example_raft_node;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about, long_about = None)]

--- a/examples/openraft-example/src/network/management.rs
+++ b/examples/openraft-example/src/network/management.rs
@@ -1,17 +1,17 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
+use actix_web::Responder;
 use actix_web::get;
 use actix_web::post;
 use actix_web::web::Data;
 use actix_web::web::Json;
-use actix_web::Responder;
-use openraft::error::Infallible;
 use openraft::BasicNode;
 use openraft::RaftMetrics;
+use openraft::error::Infallible;
 
-use crate::app::App;
 use crate::TvrNodeId;
+use crate::app::App;
 
 // --- Cluster management
 
@@ -22,8 +22,8 @@ use crate::TvrNodeId;
 /// (by calling `change-membership`)
 #[post("/add-learner")]
 pub async fn add_learner(app: Data<App>, req: Json<(TvrNodeId, String)>) -> actix_web::Result<impl Responder> {
-    let node_id = req.0 .0;
-    let node = BasicNode { addr: req.0 .1.clone() };
+    let node_id = req.0.0;
+    let node = BasicNode { addr: req.0.1.clone() };
     let res = app.raft.add_learner(node_id, node, true).await;
     Ok(Json(res))
 }

--- a/examples/openraft-example/src/network/raft.rs
+++ b/examples/openraft-example/src/network/raft.rs
@@ -1,4 +1,4 @@
-use crate::ValueConfig;
+use crate::ExampleConfig;
 use crate::app::App;
 use actix_web::Responder;
 use actix_web::post;
@@ -18,13 +18,13 @@ pub async fn vote(app: Data<App>, req: Json<VoteRequest<TvrNodeId>>) -> actix_we
 }
 
 #[post("/raft-append")]
-pub async fn append(app: Data<App>, req: Json<AppendEntriesRequest<ValueConfig>>) -> actix_web::Result<impl Responder> {
+pub async fn append(app: Data<App>, req: Json<AppendEntriesRequest<ExampleConfig>>) -> actix_web::Result<impl Responder> {
     let res = app.raft.append_entries(req.0).await;
     Ok(Json(res))
 }
 
 #[post("/raft-snapshot")]
-pub async fn snapshot(app: Data<App>, req: Json<InstallSnapshotRequest<ValueConfig>>) -> actix_web::Result<impl Responder> {
+pub async fn snapshot(app: Data<App>, req: Json<InstallSnapshotRequest<ExampleConfig>>) -> actix_web::Result<impl Responder> {
     let res = app.raft.install_snapshot(req.0).await;
     Ok(Json(res))
 }

--- a/examples/openraft-example/src/state.rs
+++ b/examples/openraft-example/src/state.rs
@@ -1,0 +1,286 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use openraft::storage::{RaftStateMachine, Snapshot};
+use openraft::{AnyError, Entry, EntryPayload, ErrorSubject, ErrorVerb, LogId, OptionalSend, RaftSnapshotBuilder, SnapshotMeta, StorageError, StorageIOError, StoredMembership};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use timevault::PartitionHandle;
+use timevault::raft::state::{SnapshotData, StateMachineData, StoredSnapshot};
+use timevault::raft::{TvrNode, TvrNodeId};
+use timevault::store::disk::atomic::atomic_write_json;
+use uuid::Uuid;
+
+use crate::ExampleConfig;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ExampleEvent {
+    DeviceOffline { event_id: Uuid, device_id: Uuid, timestamp: i64 },
+    DeviceOnline { event_id: Uuid, device_id: Uuid, timestamp: i64 },
+}
+
+impl ExampleEvent {
+    pub fn device_id(&self) -> Uuid {
+        match self {
+            ExampleEvent::DeviceOffline { device_id, .. } => *device_id,
+            ExampleEvent::DeviceOnline { device_id, .. } => *device_id,
+        }
+    }
+
+    pub fn event_id(&self) -> Uuid {
+        match self {
+            ExampleEvent::DeviceOffline { event_id, .. } => *event_id,
+            ExampleEvent::DeviceOnline { event_id, .. } => *event_id,
+        }
+    }
+
+    pub fn timestamp(&self) -> i64 {
+        match self {
+            ExampleEvent::DeviceOffline { timestamp, .. } => *timestamp,
+            ExampleEvent::DeviceOnline { timestamp, .. } => *timestamp,
+        }
+    }
+
+    pub fn is_online(&self) -> bool {
+        matches!(self, ExampleEvent::DeviceOnline { .. })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExampleResponse {
+    pub code: u16,
+    pub message: Option<String>,
+}
+
+impl Default for ExampleResponse {
+    fn default() -> Self {
+        Self { code: 200, message: None }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DeviceStatus {
+    pub device_id: Uuid,
+    pub is_online: bool,
+    pub last_event_id: Uuid,
+    pub last_timestamp: i64,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct SnapshotState {
+    devices: HashMap<Uuid, DeviceStatus>,
+}
+
+pub type SharedDeviceState = Arc<RwLock<HashMap<Uuid, DeviceStatus>>>;
+
+pub fn new_shared_device_state() -> SharedDeviceState {
+    Arc::new(RwLock::new(HashMap::new()))
+}
+
+fn storage_error<E>(subject: ErrorSubject<TvrNodeId>, verb: ErrorVerb, err: E) -> StorageError<TvrNodeId>
+where
+    E: ToString,
+{
+    StorageError::from(StorageIOError::new(subject, verb, AnyError::new(&std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))))
+}
+
+#[derive(Debug)]
+pub struct ExampleStateMachine {
+    partition_handle: PartitionHandle,
+    data: StateMachineData,
+    snapshot_idx: u64,
+    devices: SharedDeviceState,
+}
+
+impl Clone for ExampleStateMachine {
+    fn clone(&self) -> Self {
+        Self {
+            partition_handle: self.partition_handle.clone(),
+            data: self.data.clone(),
+            snapshot_idx: self.snapshot_idx,
+            devices: self.devices.clone(),
+        }
+    }
+}
+
+impl ExampleStateMachine {
+    pub fn new(partition_handle: PartitionHandle, devices: SharedDeviceState) -> Result<Self, StorageError<TvrNodeId>> {
+        let mut sm = Self {
+            partition_handle,
+            data: StateMachineData {
+                last_applied_log_id: None,
+                last_membership: Default::default(),
+            },
+            snapshot_idx: 0,
+            devices,
+        };
+
+        if let Some(snapshot) = sm.get_current_snapshot_()? {
+            sm.update_state_machine_(snapshot)?;
+        }
+
+        Ok(sm)
+    }
+
+    fn update_state_machine_(&mut self, snapshot: StoredSnapshot) -> Result<(), StorageError<TvrNodeId>> {
+        self.data.last_applied_log_id = snapshot.meta.last_log_id;
+        self.data.last_membership = snapshot.meta.last_membership.clone();
+
+        let snapshot_state: SnapshotState = if snapshot.data.is_empty() {
+            SnapshotState::default()
+        } else {
+            serde_json::from_slice(&snapshot.data).map_err(|e| storage_error(ErrorSubject::Store, ErrorVerb::Read, e))?
+        };
+        let mut guard = self.devices.write();
+        guard.clear();
+        guard.extend(snapshot_state.devices.into_iter());
+
+        Ok(())
+    }
+
+    fn get_current_snapshot_(&self) -> Result<Option<StoredSnapshot>, StorageError<TvrNodeId>> {
+        let path = self.state_file_path();
+        match std::fs::File::open(&path) {
+            Ok(file) => {
+                let snapshot: Option<StoredSnapshot> = serde_json::from_reader(file).map_err(|e| storage_error(ErrorSubject::Store, ErrorVerb::Read, e))?;
+                Ok(snapshot)
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(storage_error(ErrorSubject::Store, ErrorVerb::Read, err)),
+        }
+    }
+
+    fn set_current_snapshot_(&self, snapshot: StoredSnapshot) -> Result<(), StorageError<TvrNodeId>> {
+        atomic_write_json(self.state_file_path(), &snapshot).map_err(|e| storage_error(ErrorSubject::Store, ErrorVerb::Write, e))
+    }
+
+    fn append_event(&self, event: &ExampleEvent) -> Result<(), StorageError<TvrNodeId>> {
+        let timestamp = event.timestamp();
+        let order_key = timestamp.max(0) as u64;
+        let mut record = serde_json::to_vec(event).map_err(|e| storage_error(ErrorSubject::Store, ErrorVerb::Write, e))?;
+        record.push(b'\n');
+        self.partition_handle.append(order_key, &record).map_err(|e| storage_error(ErrorSubject::Store, ErrorVerb::Write, e))?;
+        Ok(())
+    }
+
+    fn state_file_path(&self) -> std::path::PathBuf {
+        let part_dir = timevault::store::paths::partition_dir(self.partition_handle.root(), self.partition_handle.id());
+        part_dir.join("raft_state.json")
+    }
+
+    fn apply_event(&self, event: &ExampleEvent) -> Result<(), StorageError<TvrNodeId>> {
+        self.append_event(event)?;
+        let mut guard = self.devices.write();
+        let status = DeviceStatus {
+            device_id: event.device_id(),
+            is_online: event.is_online(),
+            last_event_id: event.event_id(),
+            last_timestamp: event.timestamp(),
+        };
+        guard.insert(status.device_id, status);
+        Ok(())
+    }
+}
+
+impl RaftSnapshotBuilder<ExampleConfig> for ExampleStateMachine {
+    async fn build_snapshot(&mut self) -> Result<Snapshot<ExampleConfig>, StorageError<TvrNodeId>> {
+        let last_applied_log = self.data.last_applied_log_id;
+        let last_membership = self.data.last_membership.clone();
+
+        let snapshot_id = if let Some(last) = last_applied_log {
+            format!("{}-{}-{}", last.leader_id, last.index, self.snapshot_idx)
+        } else {
+            format!("--{}", self.snapshot_idx)
+        };
+
+        let meta = SnapshotMeta {
+            last_log_id: last_applied_log,
+            last_membership,
+            snapshot_id,
+        };
+
+        let snapshot_state = SnapshotState { devices: self.devices.read().clone() };
+        let data = serde_json::to_vec(&snapshot_state).map_err(|e| storage_error(ErrorSubject::Store, ErrorVerb::Write, e))?;
+
+        let snapshot = StoredSnapshot { meta: meta.clone(), data: data.clone() };
+        self.set_current_snapshot_(snapshot)?;
+
+        Ok(Snapshot {
+            meta,
+            snapshot: Box::new(std::io::Cursor::new(data)),
+        })
+    }
+}
+
+impl RaftStateMachine<ExampleConfig> for ExampleStateMachine {
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(&mut self) -> Result<(Option<LogId<TvrNodeId>>, StoredMembership<TvrNodeId, TvrNode>), StorageError<TvrNodeId>> {
+        Ok((self.data.last_applied_log_id, self.data.last_membership.clone()))
+    }
+
+    async fn apply<I>(&mut self, entries: I) -> Result<Vec<ExampleResponse>, StorageError<TvrNodeId>>
+    where
+        I: IntoIterator<Item = Entry<ExampleConfig>> + OptionalSend,
+        I::IntoIter: OptionalSend,
+    {
+        let entries = entries.into_iter();
+        let mut replies = Vec::with_capacity(entries.size_hint().0);
+
+        for entry in entries {
+            self.data.last_applied_log_id = Some(entry.log_id);
+
+            let response = match entry.payload {
+                EntryPayload::Blank => ExampleResponse::default(),
+                EntryPayload::Normal(event) => {
+                    self.apply_event(&event)?;
+                    ExampleResponse::default()
+                }
+                EntryPayload::Membership(mem) => {
+                    self.data.last_membership = StoredMembership::new(Some(entry.log_id), mem);
+                    ExampleResponse::default()
+                }
+            };
+
+            replies.push(response);
+        }
+
+        Ok(replies)
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.snapshot_idx += 1;
+        self.clone()
+    }
+
+    async fn begin_receiving_snapshot(&mut self) -> Result<Box<std::io::Cursor<Vec<u8>>>, StorageError<TvrNodeId>> {
+        Ok(Box::new(std::io::Cursor::new(Vec::new())))
+    }
+
+    async fn install_snapshot(&mut self, meta: &SnapshotMeta<TvrNodeId, TvrNode>, snapshot: Box<SnapshotData>) -> Result<(), StorageError<TvrNodeId>> {
+        let new_snapshot = StoredSnapshot {
+            meta: meta.clone(),
+            data: snapshot.into_inner(),
+        };
+
+        self.update_state_machine_(new_snapshot.clone())?;
+        self.set_current_snapshot_(new_snapshot)?;
+
+        Ok(())
+    }
+
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<ExampleConfig>>, StorageError<TvrNodeId>> {
+        let stored = self.get_current_snapshot_()?;
+        Ok(stored.map(|snap| Snapshot {
+            meta: snap.meta.clone(),
+            snapshot: Box::new(std::io::Cursor::new(snap.data.clone())),
+        }))
+    }
+}
+
+impl ExampleStateMachine {
+    pub fn devices(&self) -> SharedDeviceState {
+        self.devices.clone()
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated `ExampleEvent`-driven state machine that records device status updates and stores every event in a timevault partition
- expose shared device status from the application, implement the timevault `DataTransfer` trait, and add HTTP endpoints for manifest/chunk/index downloads plus a status-focused read API
- update the HTTP client, server wiring, and integration test to use the new device event workflow and depend on `parking_lot`

## Testing
- cargo test --package openraft-example

------
https://chatgpt.com/codex/tasks/task_b_68da1748262c832c8dead06716668e69