### PR TITLE
Review code and identify top issues

### DIFF
--- a/timevault/src/raft/log.rs
+++ b/timevault/src/raft/log.rs
@@ -185,7 +185,9 @@ where
     fn drop(&mut self) {
         let _ = self.tx.send(Op::Shutdown);
         if let Some(h) = self.thread_handle.take() {
-            let _ = h.join();
+            if let Err(e) = h.join() {
+                std::panic::resume_unwind(e);
+            }
         }
     }
 }
@@ -232,15 +234,11 @@ where
     D: serde::Serialize + DeserializeOwned + openraft::AppData,
     R: openraft::AppDataResponse,
 {
-    let plugin = match crate::store::plugins::resolve_plugin("jsonl") {
-        Ok(p) => p,
-        Err(_) => return Vec::new(),
-    };
+    let plugin = crate::store::plugins::resolve_plugin("jsonl")
+        .expect("jsonl plugin must be available");
     let mut cur = Cursor::new(buf);
-    let mut sc = match plugin.scanner(&mut cur) {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
-    };
+    let mut sc = plugin.scanner(&mut cur)
+        .expect("failed to create scanner for raft log buffer");
 
     let mut out = Vec::new();
     while let Ok(Some(meta)) = sc.next() {
@@ -248,27 +246,44 @@ where
         let start = meta.offset as usize;
         let end = start + meta.len as usize;
         if end > buf.len() {
-            break;
+            panic!(
+                "raft log corruption in partition {}: record at offset {} with len {} exceeds buffer size {}",
+                part.short_id(), start, meta.len, buf.len()
+            );
         }
         let line = &buf[start..end];
-        if let Ok(rec) = serde_json::from_slice::<JsonlRecord>(line) {
-            if !range.contains(&rec.log_id.index) {
-                continue;
+        let rec = match serde_json::from_slice::<JsonlRecord>(line) {
+            Ok(r) => r,
+            Err(e) => {
+                let preview = String::from_utf8_lossy(&line[..line.len().min(200)]);
+                panic!(
+                    "raft log corruption in partition {}: failed to parse JSON record at offset {}: {}. Preview: {}",
+                    part.short_id(), start, e, preview
+                );
             }
-            let payload = match rec.kind.as_str() {
-                "Blank" => EntryPayload::Blank,
-                "Membership" => match serde_json::from_value(rec.payload) {
-                    Ok(m) => EntryPayload::Membership(m),
-                    Err(_) => EntryPayload::Blank,
-                },
-                _ => match serde_json::from_value(rec.payload) {
-                    Ok(v) => EntryPayload::Normal(v),
-                    Err(_) => EntryPayload::Blank,
-                },
-            };
-            trace!("decode_entries {}: {} {:?}", part.short_id(), rec.log_id, &payload);
-            out.push(Entry { log_id: rec.log_id, payload });
+        };
+        if !range.contains(&rec.log_id.index) {
+            continue;
         }
+        let payload = match rec.kind.as_str() {
+            "Blank" => EntryPayload::Blank,
+            "Membership" => match serde_json::from_value(rec.payload.clone()) {
+                Ok(m) => EntryPayload::Membership(m),
+                Err(e) => panic!(
+                    "raft log corruption in partition {}: failed to parse Membership payload at log_id {}: {}",
+                    part.short_id(), rec.log_id, e
+                ),
+            },
+            _ => match serde_json::from_value(rec.payload.clone()) {
+                Ok(v) => EntryPayload::Normal(v),
+                Err(e) => panic!(
+                    "raft log corruption in partition {}: failed to parse Normal payload at log_id {}: {}",
+                    part.short_id(), rec.log_id, e
+                ),
+            },
+        };
+        trace!("decode_entries {}: {} {:?}", part.short_id(), rec.log_id, &payload);
+        out.push(Entry { log_id: rec.log_id, payload });
     }
     out
 }
@@ -370,7 +385,7 @@ where
     R: openraft::AppDataResponse,
 {
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(&mut self, range: RB) -> Result<Vec<Entry<TvrConfig<D, R>>>, StorageError<TvrNodeId>> {
-        self.get_log_reader().await.try_get_log_entries(range).await // FIXME I'm not sure about this line, just added await until it started to work
+        self.get_log_reader().await.try_get_log_entries(range).await
     }
 }
 

--- a/timevault/src/store/disk/index.rs
+++ b/timevault/src/store/disk/index.rs
@@ -34,9 +34,9 @@ pub fn create_empty_index_file(rt: &crate::store::partition::PartitionRuntime, c
     let ip = crate::store::paths::index_file(&chunks_dir, chunk_id);
     let mut f = OpenOptions::new().create(true).write(true).open(&ip)?;
     f.flush()?;
-    let _ = f.sync_all();
+    f.sync_all().expect("fsync index file failed");
     if let Some(dir) = ip.parent() {
-        let _ = crate::store::fsync::fsync_dir(dir);
+        crate::store::fsync::fsync_dir(dir).expect("fsync chunks dir failed");
     }
     Ok(())
 }
@@ -52,11 +52,11 @@ pub fn rewrite_index_atomic(path: &std::path::Path, lines: &[IndexLine]) -> Resu
             f.write_all(&buf)?;
         }
         f.flush()?;
-        let _ = f.sync_all();
+        f.sync_all().expect("fsync index tmp file failed");
     }
     std::fs::rename(&tmp, path)?;
     if let Some(dir) = path.parent() {
-        let _ = crate::store::fsync::fsync_dir(dir);
+        crate::store::fsync::fsync_dir(dir).expect("fsync index dir failed");
     }
     Ok(())
 }

--- a/timevault/src/store/disk/manifest.rs
+++ b/timevault/src/store/disk/manifest.rs
@@ -66,9 +66,8 @@ pub fn close_manifest_line(path: &std::path::Path, rt: &crate::store::partition:
         f.sync_all()?;
     }
     std::fs::rename(&tmp, path)?;
-    // Best-effort fsync dir
     if let Some(dir) = path.parent() {
-        let _ = crate::store::fsync::fsync_dir(dir);
+        crate::store::fsync::fsync_dir(dir).expect("fsync manifest dir failed");
     }
     Ok(())
 }
@@ -88,7 +87,7 @@ pub fn rewrite_manifest_atomic(path: &std::path::Path, lines: &[ManifestLine]) -
     }
     std::fs::rename(&tmp, path)?;
     if let Some(dir) = path.parent() {
-        let _ = crate::store::fsync::fsync_dir(dir);
+        crate::store::fsync::fsync_dir(dir).expect("fsync manifest dir failed");
     }
     Ok(())
 }

--- a/timevault/src/store/partition/append.rs
+++ b/timevault/src/store/partition/append.rs
@@ -26,9 +26,7 @@ pub fn append(h: &PartitionHandle, order_key: u64, payload: &[u8]) -> Result<cra
         {
             return Ok(crate::store::partition::AppendAck { offset: rt.cur_chunk_size_bytes });
         }
-        if ensure_ordering(&rt, order_key)?.is_none() {
-            return Ok(crate::store::partition::AppendAck { offset: rt.cur_chunk_size_bytes });
-        }
+        ensure_ordering(&rt, order_key)?;
         maybe_roll(h, &part_dir, &mut rt, order_key, payload.len() as u64)?;
         let chunk_id = rt.cur_chunk_id.expect("chunk id set by maybe_roll/start_new_chunk");
         let off = append_to_chunk(&chunks_dir, chunk_id, &payload)?; // payload is opaque, it is the responsibility of the caller to validate it
@@ -54,11 +52,14 @@ pub fn set_config(h: &PartitionHandle, delta: crate::store::partition::Partition
     Ok(())
 }
 
-fn ensure_ordering(rt: &crate::store::partition::PartitionRuntime, order_key: u64) -> Result<Option<()>> {
+fn ensure_ordering(rt: &crate::store::partition::PartitionRuntime, order_key: u64) -> Result<()> {
     if rt.cur_chunk_id.is_some() && order_key < rt.cur_chunk_max_order_key {
-        return Ok(None);
+        return Err(TvError::OutOfOrder {
+            ts_ms: order_key as i64,
+            last: rt.cur_chunk_max_order_key as i64,
+        });
     }
-    Ok(Some(()))
+    Ok(())
 }
 
 fn maybe_roll(h: &PartitionHandle, part_dir: &std::path::Path, rt: &mut crate::store::partition::PartitionRuntime, order_key: u64, next_len: u64) -> Result<()> {

--- a/timevault/src/store/partition/misc.rs
+++ b/timevault/src/store/partition/misc.rs
@@ -45,7 +45,7 @@ pub(crate) fn delete_chunk_files(chunks_dir: &std::path::Path, ids: &[u64]) {
         let _ = fs::remove_file(cp);
         let _ = fs::remove_file(ip);
     }
-    let _ = crate::store::fsync::fsync_dir(chunks_dir);
+    crate::store::fsync::fsync_dir(chunks_dir).expect("fsync chunks dir after delete failed");
 }
 
 pub(crate) fn refresh_runtime(h: &PartitionHandle, meta: &crate::store::disk::metadata::MetadataJson) -> Result<()> {
@@ -66,6 +66,6 @@ pub(crate) fn truncate_file(path: &std::path::Path, new_len: u64) -> Result<()> 
     use std::fs::OpenOptions;
     let f = OpenOptions::new().write(true).open(path)?;
     f.set_len(new_len)?;
-    let _ = f.sync_all();
+    f.sync_all().expect("fsync after truncate failed");
     Ok(())
 }

--- a/timevault/src/store/partition/purge.rs
+++ b/timevault/src/store/partition/purge.rs
@@ -146,7 +146,7 @@ fn purge_chunk_from_start(chunks_dir: &std::path::Path, chunk_id: u64, cutoff_ke
             // Truncate file to 0
             let cf = OpenOptions::new().write(true).open(&chunk_path)?;
             cf.set_len(0)?;
-            let _ = cf.sync_all();
+            cf.sync_all().expect("fsync chunk file after truncate failed");
             return Ok((false, None, was_closed_max));
         }
     };
@@ -234,10 +234,10 @@ fn rewrite_file_from_offset(path: &std::path::Path, start_off: u64) -> Result<u6
         total += n as u64;
     }
     dst.flush()?;
-    let _ = dst.sync_all();
+    dst.sync_all().expect("fsync chunk tmp file failed");
     std::fs::rename(&tmp, path)?;
     if let Some(dir) = path.parent() {
-        let _ = crate::store::fsync::fsync_dir(dir);
+        crate::store::fsync::fsync_dir(dir).expect("fsync chunks dir failed");
     }
     // Ensure new file size is set (rename preserves size)
     Ok(total)

--- a/timevault/src/store/snapshot.rs
+++ b/timevault/src/store/snapshot.rs
@@ -550,7 +550,7 @@ fn finalize_download(tmp_path: &Path, final_path: &Path) -> Result<()> {
     }
     fs::rename(tmp_path, final_path)?;
     if let Some(dir) = final_path.parent() {
-        let _ = crate::store::fsync::fsync_dir(dir);
+        crate::store::fsync::fsync_dir(dir).expect("fsync dir after download failed");
     }
     Ok(())
 }

--- a/timevault/tests/append_edge_tests.rs
+++ b/timevault/tests/append_edge_tests.rs
@@ -41,7 +41,7 @@ fn read_manifest_lines(p: &std::path::Path) -> Vec<ManifestLine> {
 }
 
 #[test]
-fn append_out_of_order_is_ignored() {
+fn append_out_of_order_returns_error() {
     let td = TempDir::new().unwrap();
     let root = td.path().to_path_buf();
     let id = Uuid::now_v7();
@@ -56,11 +56,15 @@ fn append_out_of_order_is_ignored() {
     let chunk_path = paths::chunk_file(&paths::chunks_dir(&part_dir), chunk_id);
     let before = std::fs::read(&chunk_path).unwrap();
 
-    let ack = h.append(999, &enc(999, serde_json::json!("b"))).unwrap();
-    assert_eq!(ack.offset as usize, before.len());
+    // Out-of-order append should return an error
+    let result = h.append(999, &enc(999, serde_json::json!("b")));
+    assert!(result.is_err(), "out-of-order append should return an error");
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("out of order"), "error should mention out of order: {}", err);
 
+    // Data should be unchanged
     let after = std::fs::read(&chunk_path).unwrap();
-    assert_eq!(before, after, "out-of-order append should be ignored");
+    assert_eq!(before, after, "out-of-order append should not modify data");
 }
 
 #[test]


### PR DESCRIPTION
- return OutOfOrder error instead of silently dropping out-of-order appends
- panic on fsync/sync_all failures to ensure durability guarantees
- remove uncertain FIXME comment in raft log reader (delegation is correct)
- propagate thread panics in TvrLogAdapter::drop using resume_unwind
- panic on malformed JSON records during raft log decode with detailed error info
- update test to expect error on out-of-order append